### PR TITLE
Allow intra-robot loop cloures with LiDAR place recognition

### DIFF
--- a/cslam/global_descriptor_loop_closure_detection.py
+++ b/cslam/global_descriptor_loop_closure_detection.py
@@ -152,10 +152,13 @@ class GlobalDescriptorLoopClosureDetection(object):
             embedding (np.array): descriptor
             kf_id (int): keyframe ID
         """
-        # Add for matching
-        matches = self.lcm.add_local_global_descriptor(embedding, kf_id)
+
         # Local matching
         self.detect_intra(embedding, kf_id)
+        
+        # Add for matching
+        matches = self.lcm.add_local_global_descriptor(embedding, kf_id)
+        
 
         # Store global descriptor
         msg = GlobalDescriptor()

--- a/cslam/lidar_pr/icp_utils.py
+++ b/cslam/lidar_pr/icp_utils.py
@@ -91,8 +91,12 @@ def Rt2T(R, t):
 
 
 def downsample(points, voxel_size):
+
+    mask = np.isfinite(points).all(axis=1)
+    filtered_points = points[mask]
+
     open3d_cloud = open3d.geometry.PointCloud()
-    open3d_cloud.points = open3d.utility.Vector3dVector(points)
+    open3d_cloud.points = open3d.utility.Vector3dVector(filtered_points)
     return open3d_cloud.voxel_down_sample(voxel_size=voxel_size)
 
 

--- a/cslam/loop_closure_sparse_matching.py
+++ b/cslam/loop_closure_sparse_matching.py
@@ -77,7 +77,7 @@ class LoopClosureSparseMatching(object):
 
         if len(kfs) > 0 and kfs[0] == kf_id:
             kfs, similarities = kfs[1:], similarities[1:]
-        if len(kfs) == 0:
+        if len(kfs) == 0 or kfs[0] == None:
             return None, None
 
         for kf, similarity in zip(kfs, similarities):


### PR DESCRIPTION
This fixes an issue that did not allow intra-robot loop cloures when using LiDAR place recognition.
Before the embedding of the current keyframe was added to the kdtree, and then the kd-tree was searched to obtain the most similar embedding, which resulted in always getting the current kf, which obviously was discarded.
Now we first search the kdtree for the most similar kf, and then we add the current embedding to the kdtree, see commit
ef6c3468d7d8cdffbfb464fa4bbb42f669dab41c

This PR also includes a minor fix when doing the pointcloud voxelgrid downsampling in commit c18c01b645e5c5e5e4f0e7f49381ebb5d894e2dc