### PR TITLE
fix: Import error for versions older than iron

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -g)
 endif()
 
+IF("$ENV{ROS_DISTRO}" STRLESS "iron")
+  add_definitions(-DPRE_ROS_IRON)
+ENDIF()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)

--- a/include/cslam/front_end/rgbd_handler.h
+++ b/include/cslam/front_end/rgbd_handler.h
@@ -26,7 +26,11 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
+#ifdef PRE_ROS_IRON
+#include <cv_bridge/cv_bridge.h>
+#else
 #include <cv_bridge/cv_bridge.hpp>
+#endif
 
 #include <chrono>
 #include <cslam_common_interfaces/msg/keyframe_odom.hpp>

--- a/include/cslam/front_end/visualization_utils.h
+++ b/include/cslam/front_end/visualization_utils.h
@@ -3,14 +3,22 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#ifdef PRE_ROS_IRON
+#include <cv_bridge/cv_bridge.h>
+#else
 #include <cv_bridge/cv_bridge.hpp>
+#endif
 
 #include <chrono>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <rtabmap/core/SensorData.h>
+#ifdef PRE_ROS_IRON
+#include <image_geometry/pinhole_camera_model.h>
+#else
 #include <image_geometry/pinhole_camera_model.hpp>
+#endif
 #include <cslam_common_interfaces/msg/keyframe_odom.hpp>
 #include <deque>
 #include <functional>


### PR DESCRIPTION
For ROS versions older than iron `cv_bridge.h` needs to be used instead of `cv_bridge.hpp`. This PR introduces an CMake definition to correctly import `cv_bridge` based on the `ROS_DISTRO` environment variable.

Implementation inspired by RTABMAP: https://github.com/introlab/rtabmap_ros/commit/911e4e89412c9658d569c0258730cb386b493d77